### PR TITLE
Delete the correct website when deleting a tenant

### DIFF
--- a/app/Tenant.php
+++ b/app/Tenant.php
@@ -29,9 +29,8 @@ class Tenant
     {
 
         if ($hostname = Hostname::where('fqdn', $fqdn)->with(['website'])->firstOrFail()) {
-            $website = $hostname->website->first();
             app(HostnameRepository::class)->delete($hostname, true);
-            app(WebsiteRepository::class)->delete($website, true);
+            app(WebsiteRepository::class)->delete($hostname->website, true);
         }
 
     }


### PR DESCRIPTION
When calling first() on the website object the first website in the database was being retrieved (it is not the relationship that was being accessed, so all websites could be accessed). This results in the wrong website being deleted when more than one tenant had been created and the more recent tenant deleted.